### PR TITLE
Fix issue #5

### DIFF
--- a/scripts/restore
+++ b/scripts/restore
@@ -96,6 +96,7 @@ systemctl enable $app.service
 #=================================================
 
 ynh_restore_file "/home/yunohost.app/$app"
+chown -R "$app:$app" "/home/yunohost.app/$app"
 
 #=================================================
 # INTEGRATE SERVICE IN YUNOHOST


### PR DESCRIPTION
Explicity set the correct owner and group for the data dir during
backup restore

## Problem
Fix issue #5 

## Solution
Explicity set the correct owner and group for the data dir during
backup restore

## PR Status
- [ x] Code finished.
- [ ] Tested with Package_check.
- [ x] Fix or enhancement tested.
- [ x] Upgrade from last version tested.
- [ x] Can be reviewed and tested.

## Package_check results
Havn't tested with package_check.sh because I don't have a proper dev env setup (yet!). And I run Kubuntu on my laptop. It wouldn't install there. Hopefully this one should be okay anyway, otherwise I will fix it.
